### PR TITLE
fix for 'play from here' not working

### DIFF
--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -30,13 +30,14 @@ def play(url):
         p = classes.Program()
         p.parse_xbmc_url(url)
 
-        listitem=xbmcgui.ListItem(label=p.get_list_title(), iconImage=p.thumbnail, thumbnailImage=p.thumbnail)
+        listitem=xbmcgui.ListItem(label=p.get_list_title(),
+        iconImage=p.thumbnail, thumbnailImage=p.thumbnail, path=p.get_url())
         listitem.setInfo('video', p.get_xbmc_list_item())
 
         if hasattr(listitem, 'addStreamInfo'):
             listitem.addStreamInfo('audio', p.get_xbmc_audio_stream_info())
             listitem.addStreamInfo('video', p.get_xbmc_video_stream_info())
-    
-        xbmc.Player().play(p.get_url(), listitem)
+
+        xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, listitem=listitem)
     except:
         utils.handle_error("Unable to play video")

--- a/resources/lib/programs.py
+++ b/resources/lib/programs.py
@@ -34,6 +34,7 @@ def make_programs_list(url):
         for p in programs:
             listitem = xbmcgui.ListItem(label=p.get_list_title(), iconImage=p.get_thumbnail(), thumbnailImage=p.get_thumbnail())
             listitem.setInfo('video', p.get_xbmc_list_item())
+            listitem.setProperty('IsPlayable', 'true')
 
             if hasattr(listitem, 'addStreamInfo'):
                 listitem.addStreamInfo('audio', p.get_xbmc_audio_stream_info())


### PR DESCRIPTION
Use xbmcplugin.setResolvedUrl instead of xbmc.Player().play method. This fixes bad behavior when using 'Play from here' context menu option. The xbmc.Player().play method seems to race through the list of videos only playing a couple of seconds every few videos or so.