### PR TITLE
Add support for subtitles

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -9,4 +9,5 @@
     <string id="10090">Video Transport</string>
     <string id="10091">RTMP</string>
     <string id="10092">HTTP</string>
+	<string id="10093">Enable Subtitles</string>
 </strings>

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -47,6 +47,7 @@ config_url   = 'http://www.abc.net.au/iview/xml/config.xml?r=%d' % api_version
 auth_url     = 'http://tviview.abc.net.au/iview/auth/?v2'
 programs_url = 'http://iview.abc.net.au/api/search/programs'
 feed_url     = 'https://tviview.abc.net.au/iview/feed/lg/'
+subtitle_url = 'http://cdn.iview.abc.net.au/cc/'
 
 series_url   = 'http://www.abc.net.au/iview/api/series_mrss.htm?id=%s'
 redirect_url = 'http://iview.abc.net.au/redirect/legacy/?url='

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -95,7 +95,7 @@ def parse_categories(soup):
 def parse_programme_from_feed(data):
     xml = ET.fromstring(data)
     show_list = []
-    
+
     for item in xml.getiterator('item'):
 
         title = item.find('title').text
@@ -192,4 +192,26 @@ def parse_programs_from_feed(data):
 
     return programs_list
 
+
+
+def convert_timecode(start, end):
+    """ convert iview xml timecode attribute to subrip srt standard"""
+    return start[:8]+','+start[9:11]+'0'+' --> '+end[:8]+','+end[9:11]+'0'
+
+
+def convert_to_srt(data):
+    """ convert our iview xml subtitles to subrip SRT format"""
+    tree = ET.fromstring(data)
+    root = tree.find('reel')
+    result = ""
+    count = 1
+    for elem in root.findall('title'):
+        result += str(count) + '\n'
+        result += convert_timecode(elem.get('start'), elem.get('end'))+'\n'
+        st = elem.text.split('|')
+        for line in st:
+            result += line + '\n'
+        result += '\n'
+        count +=1
+    return result.encode('utf-8')
 

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -20,10 +20,14 @@
 #
 
 import sys
+import os
+import urllib2
 import classes
 import comm
 import config
+import parse
 import utils
+import xbmc
 import xbmcgui
 import xbmcplugin
 import xbmcaddon
@@ -40,6 +44,25 @@ def play(url):
                                   path=p.get_url())
 
         listitem.setInfo('video', p.get_xbmc_list_item())
+
+        #add subtitles if available
+        profile = xbmcaddon.Addon().getAddonInfo('profile')
+        path = xbmc.translatePath(profile).decode('utf-8')
+        if not os.path.isdir(path):
+            os.makedirs(path)
+        subfile = xbmc.translatePath(os.path.join(path, 'subtitles.eng.srt'))
+        if os.path.isfile(subfile):
+            os.remove(subfile)
+        suburl = (config.subtitle_url+p.url[p.url.rfind('/')
+                    +1:p.url.rfind('_')]+'.xml')
+        try:
+            data = urllib2.urlopen(suburl).read()
+            f = open(subfile, 'w')
+            f.write(parse.convert_to_srt(data))
+            f.close()
+            listitem.setSubtitles([subfile])
+        except:
+            utils.log('Subtitles not available for this program')
 
         if hasattr(listitem, 'addStreamInfo'):
             listitem.addStreamInfo('audio', p.get_xbmc_audio_stream_info())

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -46,23 +46,25 @@ def play(url):
         listitem.setInfo('video', p.get_xbmc_list_item())
 
         #add subtitles if available
-        profile = xbmcaddon.Addon().getAddonInfo('profile')
-        path = xbmc.translatePath(profile).decode('utf-8')
-        if not os.path.isdir(path):
-            os.makedirs(path)
-        subfile = xbmc.translatePath(os.path.join(path, 'subtitles.eng.srt'))
-        if os.path.isfile(subfile):
-            os.remove(subfile)
-        suburl = (config.subtitle_url+p.url[p.url.rfind('/')
-                    +1:p.url.rfind('_')]+'.xml')
-        try:
-            data = urllib2.urlopen(suburl).read()
-            f = open(subfile, 'w')
-            f.write(parse.convert_to_srt(data))
-            f.close()
-            listitem.setSubtitles([subfile])
-        except:
-            utils.log('Subtitles not available for this program')
+        addon = xbmcaddon.Addon(config.ADDON_ID)
+        if addon.getSetting('subtitles_enabled') == 'true':
+            profile = xbmcaddon.Addon().getAddonInfo('profile')
+            path = xbmc.translatePath(profile).decode('utf-8')
+            if not os.path.isdir(path):
+                os.makedirs(path)
+            subfile = xbmc.translatePath(os.path.join(path, 'subtitles.eng.srt'))
+            if os.path.isfile(subfile):
+                os.remove(subfile)
+            suburl = (config.subtitle_url+p.url[p.url.rfind('/')
+                        +1:p.url.rfind('_')]+'.xml')
+            try:
+                data = urllib2.urlopen(suburl).read()
+                f = open(subfile, 'w')
+                f.write(parse.convert_to_srt(data))
+                f.close()
+                listitem.setSubtitles([subfile])
+            except:
+                utils.log('Subtitles not available for this program')
 
         if hasattr(listitem, 'addStreamInfo'):
             listitem.addStreamInfo('audio', p.get_xbmc_audio_stream_info())

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+  <category label="10080">
+    <!-- Subtitles -->
+    <setting id="subtitles_enabled" type="bool" label="10093" default="false" />
+  </category>
+</settings>


### PR DESCRIPTION
Hi Andy,

I've written a parser for iview format subtitles which seem to be an original format based in xml. There's no way of knowing which programs have them or not without requesting the url, so there's just simple exception handling to deal with it. You can get the availability and url from the web and mobile feeds but I figure it's much faster to just try as the filename is easy to guess. I have tested a fair bit and it seems to hold up.

There's a slight performance hit added with fetching the captions and parsing them - do you think there should be an addon setting for enabling subtitles like in the plus7 addon? I've tested on an i7 and a raspberry pi 2 and while the i7 isn't too bothered with <0.1s to parse the latest adam hills episode, it takes the pi about 1.5s, and I'm sure much longer on the vast amount of toasters out there running Kodi. If you're happy with what I've done so far I can implement that as well before merging.

fixes #1333 

Thanks

Glenn