### PR TITLE
Fix for subtitles

### DIFF
--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -25,6 +25,7 @@ import datetime
 import urllib
 import time
 import utils
+from HTMLParser import HTMLParser
 
 class Series(object):
 
@@ -116,6 +117,7 @@ class Program(object):
         self.thumbnail = None
         self.url = None
         self.expire = None
+        self.link = None
 
     def __repr__(self):
         return self.title
@@ -309,7 +311,7 @@ class Program(object):
         if self.date:          d['date'] = self.date.strftime("%Y-%m-%d %H:%M:%S")
         if self.thumbnail:     d['thumbnail'] = self.thumbnail
         if self.url:           d['url'] = self.url
-
+        if self.link:          d['link'] = self.link
         return utils.make_url(d)
 
 
@@ -327,7 +329,13 @@ class Program(object):
         self.rating        = d.get('rating')
         self.url           = d.get('url')
         self.thumbnail     = urllib.unquote_plus(d.get('thumbnail'))
+        self.link          = d.get('link')
         if d.has_key('date'):
            timestamp = time.mktime(time.strptime(d['date'], '%Y-%m-%d %H:%M:%S'))
            self.date = datetime.date.fromtimestamp(timestamp)
 
+class MyHTMLParser(HTMLParser):
+    def handle_data(self, data):
+        # Get metadata which includes subtitles link
+        if 'var videoParams' in data:
+            self.data = data

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -334,7 +334,7 @@ class Program(object):
            timestamp = time.mktime(time.strptime(d['date'], '%Y-%m-%d %H:%M:%S'))
            self.date = datetime.date.fromtimestamp(timestamp)
 
-class MyHTMLParser(HTMLParser):
+class HTMLMetadataParser(HTMLParser):
     def handle_data(self, data):
         # Get metadata which includes subtitles link
         if 'var videoParams' in data:

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -47,7 +47,6 @@ config_url   = 'http://www.abc.net.au/iview/xml/config.xml?r=%d' % api_version
 auth_url     = 'http://tviview.abc.net.au/iview/auth/?v2'
 programs_url = 'http://iview.abc.net.au/api/search/programs'
 feed_url     = 'https://tviview.abc.net.au/iview/feed/lg/'
-subtitle_url = 'http://cdn.iview.abc.net.au/cc/'
 
 series_url   = 'http://www.abc.net.au/iview/api/series_mrss.htm?id=%s'
 redirect_url = 'http://iview.abc.net.au/redirect/legacy/?url='

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -184,6 +184,11 @@ def parse_programs_from_feed(data):
             p.duration = int(duration)
         except:
             utils.log("Couldn't parse program duration: %s" % duration)
+            
+        try:
+            p.link = item.find('link').text
+        except:
+            pass
 
         p.date = utils.get_datetime(item.find('pubDate').text)
         p.expire = utils.get_datetime(item.find('{http://www.abc.net.au/tv/mrss}expireDate').text)
@@ -206,6 +211,8 @@ def convert_to_srt(data):
     result = ""
     count = 1
     for elem in root.findall('title'):
+        if elem.text == None:
+            continue
         result += str(count) + '\n'
         result += convert_timecode(elem.get('start'), elem.get('end'))+'\n'
         st = elem.text.split('|')

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -59,7 +59,7 @@ def play(url):
                 os.remove(subfile)
             
             try:
-                parser = classes.MyHTMLParser()
+                parser = classes.HTMLMetadataParser()
                 htmldata = urllib2.urlopen(p.link).read()
                 parser.feed(htmldata)
                 rawjson = parser.data.strip()[18:parser.data.find('};')-6]

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -22,6 +22,7 @@
 import sys
 import os
 import urllib2
+import json
 import classes
 import comm
 import config
@@ -56,9 +57,14 @@ def play(url):
             subfile = xbmc.translatePath(os.path.join(path, 'subtitles.eng.srt'))
             if os.path.isfile(subfile):
                 os.remove(subfile)
-            suburl = (config.subtitle_url+p.url[p.url.rfind('/')
-                        +1:p.url.rfind('_')]+'.xml')
+            
             try:
+                parser = classes.MyHTMLParser()
+                htmldata = urllib2.urlopen(p.link).read()
+                parser.feed(htmldata)
+                rawjson = parser.data.strip()[18:parser.data.find('};')-6]
+                utils.log(rawjson)
+                suburl = json.loads(rawjson)['captions']
                 data = urllib2.urlopen(suburl).read()
                 f = open(subfile, 'w')
                 f.write(parse.convert_to_srt(data))


### PR DESCRIPTION
The subtitle URL is no longer directly correlated to the video filename,
now we fetch the HTML for the program from the desktop API and get the
URL from there.