### PR TITLE
Switch to mobile API

### DIFF
--- a/default.py
+++ b/default.py
@@ -41,7 +41,7 @@ if __name__ == "__main__" :
       categories.make_category_list()
    elif params.has_key("play"):
       play.play(params_str)
-   elif params.has_key("series"):
+   elif params.has_key("series_url"):
       programs.make_programs_list(params_str)
    elif params.has_key("category"):
       series.make_series_list(params_str)

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -10,4 +10,5 @@
     <string id="10091">RTMP</string>
     <string id="10092">HTTP</string>
     <string id="10093">Enable Subtitles</string>
+    <string id="10094">Stream Quality</string>
 </strings>

--- a/resources/lib/categories.py
+++ b/resources/lib/categories.py
@@ -31,16 +31,15 @@ import xbmcplugin
 def make_category_list():
 
     try:
-        iview_config = comm.get_config()
-        categories = comm.get_categories(iview_config)
+        categories = comm.get_categories()
         categories = sorted(categories, key=lambda k: k['name'].lower())
         # All category is disabled for now due to API issues
         # https://github.com/andybotting/xbmc-addon-abc-iview/issues/1454
-        #categories.insert(0, {'name':'All', 'keyword':'0-z'})
+        #categories.insert(0, {'name':'All', 'path':'index?device=android-mobile&fields=seriesTitle,episodeCount,href'})
 
         ok = True
         for g in categories:
-            url = "%s?category=%s" % (sys.argv[0], g['keyword'])
+            url = "%s?category=%s" % (sys.argv[0], g['path'])
             listitem = xbmcgui.ListItem(g['name'])
 
             # Add the program item to the list

--- a/resources/lib/classes.py
+++ b/resources/lib/classes.py
@@ -25,7 +25,6 @@ import datetime
 import urllib
 import time
 import utils
-from HTMLParser import HTMLParser
 
 class Series(object):
 
@@ -33,6 +32,7 @@ class Series(object):
         self.description = None
         self.num_episodes = 1
         self.thumbnail = None
+        self.series_houseno = None
 
     def __repr__(self):
         return self.title
@@ -117,7 +117,8 @@ class Program(object):
         self.thumbnail = None
         self.url = None
         self.expire = None
-        self.link = None
+        self.subtitle_url = None
+        self.house_number = None
 
     def __repr__(self):
         return self.title
@@ -202,6 +203,13 @@ class Program(object):
         """
         if self.date:
             return self.date.strftime("%Y-%m-%d")
+        
+    def get_date_time(self):
+        """ Return string of the date/time in the format
+        2016-09-08 10:00:00 which we can use to sort episodes
+        """
+        if self.date:
+            return self.date.strftime("%Y-%m-%d %H:%M:%S")
 
     def get_year(self):
         """ Return an integer of the year of publish date
@@ -238,7 +246,13 @@ class Program(object):
         """
         if self.expire:
             return self.expire.strftime("%Y-%m-%d %h:%m:%s")
-
+    
+    def get_house_number(self):
+        """ Returns ABC's internal house number of the episode
+        """
+        if self.house_number:
+            return self.house_number
+        
     def get_xbmc_list_item(self):
         """ Returns a dict of program information, in the format which
             XBMC requires for video metadata.
@@ -311,7 +325,8 @@ class Program(object):
         if self.date:          d['date'] = self.date.strftime("%Y-%m-%d %H:%M:%S")
         if self.thumbnail:     d['thumbnail'] = self.thumbnail
         if self.url:           d['url'] = self.url
-        if self.link:          d['link'] = self.link
+        if self.subtitle_url:  d['subtitle_url'] = self.subtitle_url
+        if self.house_number:  d['house_number'] = self.house_number
         return utils.make_url(d)
 
 
@@ -329,13 +344,8 @@ class Program(object):
         self.rating        = d.get('rating')
         self.url           = d.get('url')
         self.thumbnail     = urllib.unquote_plus(d.get('thumbnail'))
-        self.link          = d.get('link')
+        self.subtitle_url  = d.get('subtitle_url')
+        self.house_number  = d.get('house_number')
         if d.has_key('date'):
            timestamp = time.mktime(time.strptime(d['date'], '%Y-%m-%d %H:%M:%S'))
            self.date = datetime.date.fromtimestamp(timestamp)
-
-class HTMLMetadataParser(HTMLParser):
-    def handle_data(self, data):
-        # Get metadata which includes subtitles link
-        if 'var videoParams' in data:
-            self.data = data

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -55,7 +55,7 @@ def fetch_url(url, headers={}):
     """
     utils.log("Fetching URL: %s" % url)
     request = urllib2.Request(url, None, dict(headers.items() + {
-        'User-Agent' : config.user_agent
+        'User-Agent' : config.user_agent[0][1]
     }.items()))
 
     attempts = 10

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -25,6 +25,8 @@ import parse
 import utils
 import gzip
 import ssl
+import json
+import threading
 from StringIO import StringIO
 
 try:
@@ -79,35 +81,19 @@ def fetch_protected_url(url):
     headers = {'Authorization': 'Basic ZmVlZHRlc3Q6YWJjMTIz'}
     return fetch_url(url, headers)
 
-def get_config():
-    """This function fetches the iView "config". Among other things,
-        it tells us an always-metered "fallback" RTMP server, and points
-        us to many of iView's other XML files.
-    """
-    iview_config = fetch_url(config.config_url)
-    return parse.parse_config(iview_config)
-
-def get_auth(iview_config):
-    """This function performs an authentication handshake with iView.
-        Among other things, it tells us if the connection is unmetered,
-        and gives us a one-time token we need to use to speak RTSP with
-        ABC's servers, and tells us what the RTMP URL is.
-    """
-    auth_config = fetch_url(config.auth_url)
-    return parse.parse_auth(auth_config, iview_config)
-
-def get_categories(iview_config):
+def get_categories():
     """Returns the list of categories
     """
-    url = config.base_url + iview_config['categories_url']
+    url = config.config_url
     category_data = fetch_url(url)
     categories = parse.parse_categories(category_data)
     return categories
 
 def get_feed(keyword):
     utils.log("Fetching feed")
-    url = config.feed_url + '?keyword=' + keyword
-    feed = cache.cacheFunction(fetch_protected_url, url)
+    url = config.feed_url.format(keyword)
+    utils.log("Fetching URL: %s" % url)
+    feed = cache.cacheFunction(fetch_url, url)
     return feed
 
 def get_programme_from_feed(keyword):
@@ -116,12 +102,23 @@ def get_programme_from_feed(keyword):
     shows = parse.parse_programme_from_feed(feed)
     return shows
 
-def get_series_from_feed(series, category='0-z'):
+def get_series_from_feed(series_url, episode_count):
     utils.log("Fetching series feed")
-    feed = get_feed(category)
-    programs = parse.parse_programs_from_feed(feed)
-    filtered = []
-    for p in programs:
-        if p.title == series:
-            filtered.append(p)
-    return filtered
+    feed = get_feed(series_url)
+    return parse.parse_programs_from_feed(feed,episode_count)
+
+def download_related(url, listobj, index):
+    listobj[index+1] = json.loads(fetch_url(config.feed_url.format(url)))
+
+def download_related_list(urls, listobj):
+    utils.log('Downloading JSON listings...')
+    threads = []
+    listobj.extend([None for x in range(len(urls))])
+    for index, url in enumerate(urls):
+        thread = threading.Thread(target=download_related, args=(url, listobj, index))
+        thread.daemon = True
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()

--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -27,6 +27,7 @@ import gzip
 import ssl
 import json
 import threading
+import cookielib
 from StringIO import StringIO
 
 try:
@@ -36,6 +37,10 @@ except:
     import storageserverdummy as StorageServer
 
 cache = StorageServer.StorageServer(config.ADDON_ID, 1)
+cj = cookielib.CookieJar()
+handler = urllib2.HTTPCookieProcessor(cj)
+opener = urllib2.build_opener(handler)
+opener.addheaders = config.user_agent
 
 class JsonRedirectHandler(urllib2.HTTPRedirectHandler): 
     def http_error_301(self, req, fp, code, msg, headers):
@@ -80,6 +85,11 @@ def fetch_protected_url(url):
     """
     headers = {'Authorization': 'Basic ZmVlZHRlc3Q6YWJjMTIz'}
     return fetch_url(url, headers)
+
+def fetch_url_withcookies(url, data=None):
+    """ Fetches a URL using a cookiejar opener"""
+    http = opener.open(url, data=None)
+    return http.read()
 
 def get_categories():
     """Returns the list of categories

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -42,20 +42,13 @@ except AttributeError:
 
 user_agent = '%s add-on for XBMC/Kodi %s%s' % (NAME, VERSION, os_string)
 
-base_url     = 'http://www.abc.net.au/iview/'
-config_url   = 'http://www.abc.net.au/iview/xml/config.xml?r=%d' % api_version
-auth_url     = 'http://tviview.abc.net.au/iview/auth/?v2'
-programs_url = 'http://iview.abc.net.au/api/search/programs'
-feed_url     = 'https://tviview.abc.net.au/iview/feed/lg/'
+base_url     = 'http://iview.abc.net.au'
+config_url   = 'http://iview.abc.net.au/api/navigation/mobile/2/?device=android-mobile&'
+auth_url     = '/auth/hls/sign?'
+index_url    = 'http://iview.abc.net.au/api/index?device=android-mobile&fields=seriesTitle,episodeCount,href'
+feed_url     = ' http://iview.abc.net.au/api/{0}?device=android-mobile&sort=az'
 
-series_url   = 'http://www.abc.net.au/iview/api/series_mrss.htm?id=%s'
-redirect_url = 'http://iview.abc.net.au/redirect/legacy/?url='
+secret = 'android.content.res.Resources'
 
-akamai_fallback_server = 'rtmp://cp53909.edgefcs.net/ondemand'
-akamai_playpath_prefix = 'flash/playback/_definst_/'
 
-# Used for "SWF verification", a stream obfuscation technique
-swf_hash    = '96cc76f1d5385fb5cda6e2ce5c73323a399043d0bb6c687edd807e5c73c42b37'
-swf_size    = '2122'
-swf_url     = 'http://www.abc.net.au/iview/images/iview.jpg'
 

--- a/resources/lib/config.py
+++ b/resources/lib/config.py
@@ -40,15 +40,16 @@ try:
 except AttributeError:
     os_string = ''
 
-user_agent = '%s add-on for XBMC/Kodi %s%s' % (NAME, VERSION, os_string)
+user_agent = [('User-Agent', 'Android SDK HW (5.31.0; 6.0; htc_himauhl; arm64-v8a)')]
+secret = 'android.content.res.Resources'
 
 base_url     = 'http://iview.abc.net.au'
 config_url   = 'http://iview.abc.net.au/api/navigation/mobile/2/?device=android-mobile&'
 auth_url     = '/auth/hls/sign?'
 index_url    = 'http://iview.abc.net.au/api/index?device=android-mobile&fields=seriesTitle,episodeCount,href'
-feed_url     = ' http://iview.abc.net.au/api/{0}?device=android-mobile&sort=az'
+feed_url     = 'http://iview.abc.net.au/api/{0}?device=android-mobile&sort=az'
 
-secret = 'android.content.res.Resources'
+
 
 
 

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -78,7 +78,7 @@ def parse_programme_from_feed(data):
                         if listing['seriesTitle'] == title:
                             show.num_episodes = listing['episodeCount']
                             break
-                    break
+            
             show.title = title
             if u'title' in item:
                 show.description = item[u'title']

--- a/resources/lib/parse.py
+++ b/resources/lib/parse.py
@@ -31,172 +31,133 @@ import json
 
 import xml.etree.ElementTree as ET
 
-from BeautifulSoup import BeautifulStoneSoup
-
-# This is a throwaway variable to deal with a python bug with strptime:
-#   ImportError: Failed to import _strptime because the import lockis
-#   held by another thread.
-throwaway = time.strptime('20140101', '%Y%m%d')
-
-def parse_config(soup):
-    """There are lots of goodies in the config we get back from the ABC.
-        In particular, it gives us the URLs of all the other XML data we
-        need.
+def parse_categories(config):
+    """ Fetch navigation json file and retrieve channels and categories.
     """
-    try:
-        soup = soup.replace('&amp;', '&#38;')
-        xml = BeautifulStoneSoup(soup)
-
-        # should look like "rtmp://cp53909.edgefcs.net/ondemand"
-        # Looks like the ABC don't always include this field.
-        # If not included, that's okay -- ABC usually gives us the server in the auth result as well.
-        rtmp_url = xml.find('param', attrs={'name':'server_streaming'}).get('value')
-        rtmp_chunks = rtmp_url.split('/')
-
-        return {
-            'rtmp_url'  : rtmp_url,
-            'rtmp_host' : rtmp_chunks[2],
-            'rtmp_app'  : rtmp_chunks[3],
-            'api_url' : xml.find('param', attrs={'name':'api'}).get('value'),
-            'categories_url' : xml.find('param', attrs={'name':'categories'}).get('value'),
-        }
-    except:
-        raise Exception("Error fetching iView config. Service possibly unavailable")
-
-
-def parse_categories(soup):
     categories_list = []
-
-    """
-    <category id="pre-school" genre="true">
-        <name>ABC 4 Kids</name>
-    </category>
-    """
-
-    # This next line is the magic to make recursive=False work (wtf?)
-    BeautifulStoneSoup.NESTABLE_TAGS["category"] = []
-    xml = BeautifulStoneSoup(soup)
-
-    # Get all the top level categories, except the alphabetical ones
-    for cat in xml.find('categories').findAll('category', recursive=False):
-
-        id = cat.get('id')
-        if cat.get('index') or id == 'index':
-            continue
-
+    data = json.loads(config)
+    categories = [x for y in [data[1]['submenus'][0]['channels'], 
+                data[1]['submenus'][1]['submenus']] for x in y]    
+    
+    for cat in categories:
         item = {}
-        item['keyword'] = id
-        item['name']    = cat.find('name').string;
-
-        categories_list.append(item);
+        item['path'] = cat['path']
+        item['name'] = cat['title']
+        categories_list.append(item)
 
     return categories_list
 
 def parse_programme_from_feed(data):
-    xml = ET.fromstring(data)
+    jsondata = json.loads(data)
     show_list = []
-
-    for item in xml.getiterator('item'):
-
-        title = item.find('title').text
-        if title.startswith('Trailer'):
-            continue
-
-        show = None
-        for s in show_list:
-            if s.title == title:
-               show = s
-               break
-
-        if show:
-            show.increment_num_episodes()
-        else:
+    href_list = []
+    show_index = json.loads(comm.fetch_url(config.index_url))
+    series_houseno_list = [(x['href'][-13:-6], x['episodeCount']) 
+                    for item in show_index['index'] for x in item['episodes']]
+    
+    for section in jsondata[u'index']:
+        for item in section[u'episodes']:
+            
+            title = item[u'seriesTitle']
+            if title.startswith(u'Trailer'):
+                continue
+            
             show = classes.Series()
+            
+            show.series_houseno = item['episodeHouseNumber'][:7]
+            
+            episode_count = 0
+            for houseno in series_houseno_list:
+                if houseno[0] == show.series_houseno:
+                    episode_count = houseno[1]
+                    show.num_episodes = episode_count
+                    break
+            if episode_count == 0: #some shows have multiple house no's
+                for group in show_index['index']:
+                    for listing in group['episodes']:
+                        if listing['seriesTitle'] == title:
+                            show.num_episodes = listing['episodeCount']
+                            break
+                    break
             show.title = title
-            show.description = item.find('description').text
-            show.thumbnail = item.find('{http://search.yahoo.com/mrss/}thumbnail').attrib['url']
+            if u'title' in item:
+                show.description = item[u'title']
+                title_match = re.match('^[Ss]eries\s?(?P<series>\w+)', show.description)
+                if title_match:
+                    show.title += ' Series ' + title_match.groups()[0]
+            else:
+                show.description = item[u'seriesTitle']
+            show.thumbnail = item['thumbnail']
+            show.series_url = item['href']
+            href_list.append(item['href'])
             show_list.append(show)
 
     return show_list
 
-def parse_programs_from_feed(data):
+def parse_programs_from_feed(data, episode_count):
 
-    xml = ET.fromstring(data)
-
+    jsondata = json.loads(data)
+    related = config.feed_url.format(jsondata['related'])
+    
     programs_list = []
-    for item in xml.getiterator('item'):
+    related_list = []
+    related_list.append(jsondata)
+    
+    if int(episode_count) > 1:
+        comm.download_related_list(parse_other_episodes(related), related_list)
+    
+    for item in related_list:
         p = classes.Program()
-
-        title = item.find('title').text
-        p.title = title
-
-        subtitle = item.find('subtitle').text
-
-        title_match = None
-        title_parts = None
-
-        if subtitle:
-            # Series 2 Episode 25 Home Is Where The Hatch Is
-            title_match = re.search('^[Ss]eries\s?(?P<series>\w+)\s[Ee]p(isode)?\s?(?P<episode>\d+)\s(?P<episode_title>.*)$', subtitle)
-            if not title_match:
-                # Series 8 Episode 13
-                title_match = re.search('^[Ss]eries\s?(?P<series>\w+)\s[Ee]p(isode)?\s?(?P<episode>\d+)$', subtitle)
-            if not title_match:
-                # Episode 34 Shape Shifter
-                title_match = re.search('^[Ee]p(isode)?\s?(?P<episode>\d+)\s(?P<episode_title>.*)$', subtitle)
-            if not title_match:
-                # Series 10 Rylan Clark, Joanna Lumley, Ant And Dec, The Vaccines
-                title_match = re.search('^[Ss]eries\s?(?P<series>\d+)\s(?P<episode_title>.*)$', subtitle)
-            if not title_match:
-                # Episode 5
-                title_match = re.search('^[Ee]p(isode)?\s?(?P<episode>\d+)$', subtitle)
-            if not title_match:
-                p.episode_title = subtitle
-
-            if title_match:
-                title_parts = title_match.groupdict()
-                p.episode_title = title_parts.get('episode_title')
+        subtitle = None
+        if 'title' in item:
+            title = item['seriesTitle']
+            subtitle = item['title']
+            p.title = title
+            p.episode_title = subtitle
+        else:
+            title = item['seriesTitle']
+            p.title = title           
+        
+        p.house_number  = item['episodeHouseNumber']
+        p.description   = item['description']
+        p.url           = item['playlist'][-1]['hls-high']
+        p.thumbnail     = item['thumbnail']
 
         try:
-            # If we have actual series/episode fields given
-            p.series        = item.find('series').text
-            p.episode       = item.find('episode').text
-        except:
-            try:
-                # If we only get series/episode in the subtitle
-                p.series        = title_parts.get('series')
-                p.episode       = title_parts.get('episode')
-            except:
-                pass
-
-        p.description   = item.find('description').text
-        p.url           = item.find('{http://www.abc.net.au/tv/mrss}videoAsset').text
-        p.thumbnail     = item.find('{http://search.yahoo.com/mrss/}thumbnail').attrib['url']
-
-        try:
-            p.rating = item.find('{http://www.abc.net.au/tv/mrss}rating').text
+            p.rating = item['rating']
         except:
             # Rating not given for all programs
             pass
 
         try:
-            duration = item.find('{http://search.yahoo.com/mrss/}content').attrib['duration']
+            duration = item['duration']
             p.duration = int(duration)
         except:
-            utils.log("Couldn't parse program duration: %s" % duration)
+            if 'duration' in locals():
+                utils.log("Couldn't parse program duration: %s" % duration)
             
         try:
-            p.link = item.find('link').text
+            p.subtitle_url = item['playlist'][-1]['captions']['src-xml']
         except:
             pass
 
-        p.date = utils.get_datetime(item.find('pubDate').text)
-        p.expire = utils.get_datetime(item.find('{http://www.abc.net.au/tv/mrss}expireDate').text)
+        p.date = utils.get_datetime(item['pubDate'])
+        p.expire = utils.get_datetime(item['expireDate'])
 
         programs_list.append(p)
+    
+    sorted_programs = sorted(programs_list, key=lambda x: x.get_date_time(), reverse=True)
+    return sorted_programs
 
-    return programs_list
-
+def parse_other_episodes(url):
+    """ return a list of URLs linking to other shows in series"""
+    data = json.loads(comm.fetch_url(url))
+    
+    related_list = []
+    
+    for episode in data['index'][0]['episodes']:
+        related_list.append(episode['href'])
+    return related_list
 
 
 def convert_timecode(start, end):

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -42,19 +42,20 @@ def play(url):
         auth = utils.get_auth(p)
         akamai_auth = utils.get_akamai_auth(auth)
         akamai_url = "{0}?hdnea={1}".format(p.get_url(), akamai_auth)
-        streams_list = comm.fetch_url_withcookies(akamai_url)
-        quality = xbmcaddon.Addon().getSetting('HLSQUALITY')
-        stream_url = parse.parse_m3u8_streams(streams_list, quality)
-        cookies = utils.cookies_to_string(comm.cj)
-        url_to_play = '{0}|{1}={2}&Cookie={3}'.format(stream_url, 
-                        config.user_agent[0][0], 
-                        urllib.quote(config.user_agent[0][1]), 
-                        urllib.quote(cookies))
+        #Test akamai URL to see if we get HTTP Success
+        try: 
+            response = urllib2.urlopen(akamai_url)
+        except urllib2.HTTPError, e:
+            utils.handle_error('HTTPError = ' + str(e.code))
+        except urllib2.URLError, e:
+            utils.handle_error('URLError = ' + str(e.reason))
+        except httplib.HTTPException, e:
+            utils.handle_error('HTTPException')
         
         listitem=xbmcgui.ListItem(label=p.get_list_title(),
                                   iconImage=p.thumbnail,
                                   thumbnailImage=p.thumbnail,
-                                  path=url_to_play)
+                                  path=akamai_url)
 
         listitem.setInfo('video', p.get_xbmc_list_item())
 

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -21,6 +21,7 @@
 
 import sys
 import os
+import urllib
 import urllib2
 import json
 import classes
@@ -41,11 +42,19 @@ def play(url):
         auth = utils.get_auth(p)
         akamai_auth = utils.get_akamai_auth(auth)
         akamai_url = "{0}?hdnea={1}".format(p.get_url(), akamai_auth)
+        streams_list = comm.fetch_url_withcookies(akamai_url)
+        quality = xbmcaddon.Addon().getSetting('HLSQUALITY')
+        stream_url = parse.parse_m3u8_streams(streams_list, quality)
+        cookies = utils.cookies_to_string(comm.cj)
+        url_to_play = '{0}|{1}={2}&Cookie={3}'.format(stream_url, 
+                        config.user_agent[0][0], 
+                        urllib.quote(config.user_agent[0][1]), 
+                        urllib.quote(cookies))
         
         listitem=xbmcgui.ListItem(label=p.get_list_title(),
                                   iconImage=p.thumbnail,
                                   thumbnailImage=p.thumbnail,
-                                  path = akamai_url)
+                                  path=url_to_play)
 
         listitem.setInfo('video', p.get_xbmc_list_item())
 

--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -38,11 +38,14 @@ def play(url):
     try:
         p = classes.Program()
         p.parse_xbmc_url(url)
-
+        auth = utils.get_auth(p)
+        akamai_auth = utils.get_akamai_auth(auth)
+        akamai_url = "{0}?hdnea={1}".format(p.get_url(), akamai_auth)
+        
         listitem=xbmcgui.ListItem(label=p.get_list_title(),
                                   iconImage=p.thumbnail,
                                   thumbnailImage=p.thumbnail,
-                                  path=p.get_url())
+                                  path = akamai_url)
 
         listitem.setInfo('video', p.get_xbmc_list_item())
 
@@ -59,13 +62,7 @@ def play(url):
                 os.remove(subfile)
             
             try:
-                parser = classes.HTMLMetadataParser()
-                htmldata = urllib2.urlopen(p.link).read()
-                parser.feed(htmldata)
-                rawjson = parser.data.strip()[18:parser.data.find('};')-6]
-                utils.log(rawjson)
-                suburl = json.loads(rawjson)['captions']
-                data = urllib2.urlopen(suburl).read()
+                data = urllib2.urlopen(p.subtitle_url).read()
                 f = open(subfile, 'w')
                 f.write(parse.convert_to_srt(data))
                 f.close()

--- a/resources/lib/programs.py
+++ b/resources/lib/programs.py
@@ -28,7 +28,7 @@ import xbmc, xbmcgui, xbmcplugin
 def make_programs_list(url):
     try:
         params = utils.get_url(url)
-        programs = comm.get_series_from_feed(params['series'], category=params['category'])
+        programs = comm.get_series_from_feed(params['series_url'], params['episode_count'])
 
         ok = True
         for p in programs:

--- a/resources/lib/series.py
+++ b/resources/lib/series.py
@@ -37,7 +37,7 @@ def make_series_list(url):
 
         ok = True
         for s in series_list:
-            url = "%s?%s" % (sys.argv[0], utils.make_url({'series': s.title, 'category': category}))
+            url = "%s?%s" % (sys.argv[0], utils.make_url({'series_url': s.series_url, 'category': category, 'episode_count': s.num_episodes}))
 
             thumbnail = s.get_thumbnail()
             listitem = xbmcgui.ListItem(s.get_list_title(), iconImage=thumbnail, thumbnailImage=thumbnail)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -46,6 +46,16 @@ def get_akamai_auth(url):
     res = urllib2.urlopen(url)
     return res.read()
 
+def cookies_to_string(cookiejar):
+    result = ""
+    for cookie in cookiejar:
+        result += cookie.name
+        result += '='
+        result += cookie.value
+        result += '; '
+    result = result[:-1]
+    return result 
+
 def get_datetime(timestamp):
     # 2016-04-18 07:00:00
     try:

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -26,16 +26,31 @@ import textwrap
 import xbmc, xbmcgui, xbmcplugin, xbmcaddon
 import config
 import issue_reporter
+import hmac
+import hashlib
 
 pattern = re.compile("&(\w+?);")
 
+def get_auth(program):
+    """ Calculate signature and build auth URL for a program"""
+    ts = str(int(time.time()))
+    hn = program.get_house_number()
+    base = config.base_url
+    path = ''.join([config.auth_url, 'ts={0}&hn={1}&d=android-mobile'.format(ts, hn)])
+    secret = config.secret
+    digest = hmac.new(secret, msg=path, digestmod=hashlib.sha256).hexdigest()
+    return ''.join([base, path, '&sig=', digest])
+
+def get_akamai_auth(url):
+    """ Access ABC auth URL and retrieve Akamai authorization data"""
+    res = urllib2.urlopen(url)
+    return res.read()
+
 def get_datetime(timestamp):
-    # Tue, 05 Aug 2014 14:45:00 +1000
+    # 2016-04-18 07:00:00
     try:
-        # strptime sucks. Remove the +1000 part from the end
-        timestamp_fixed = re.sub(r' [+-]([0-9]){4}$', '', timestamp)
-        dt = time.mktime(time.strptime(timestamp_fixed, '%a, %d %b %Y %H:%M:%S'))
-        return datetime.date.fromtimestamp(dt)
+        dt = time.mktime(time.strptime(timestamp, '%Y-%m-%d %H:%M:%S'))
+        return datetime.datetime.fromtimestamp(dt)
     except:
         log_error("Couldn't parse timestamp: %s" % timestamp)
     return

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -107,7 +107,7 @@ def make_url(d):
 
 
 def log(s):
-    print "[%s v%s] %s" % (config.NAME, config.VERSION, s)
+    xbmc.log("[%s v%s] %s" % (config.NAME, config.VERSION, s), level=xbmc.LOGNOTICE)
 
 
 def log_error(message=None):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,5 @@
   <category label="10080">
     <!-- Subtitles -->
     <setting id="subtitles_enabled" type="bool" label="10093" default="false" />
-    <setting id="HLSQUALITY" type="enum" label="10094" values="Audio only (40k/s)|Low (220k/s) |Medium (500k/s)|High (650k/s)" default="3" />
   </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,5 +3,6 @@
   <category label="10080">
     <!-- Subtitles -->
     <setting id="subtitles_enabled" type="bool" label="10093" default="false" />
+    <setting id="HLSQUALITY" type="enum" label="10094" values="Audio only (40k/s)|Low (220k/s) |Medium (500k/s)|High (650k/s)" default="3" />
   </category>
 </settings>


### PR DESCRIPTION
Switch add-on to the android/ios iView API.  The general layout has been
for the most part retained although there are some differences in the
program categories.
I've borrowed the threading code from the plus7 add-on to speed up the
listing of episodes as we now have to fetch each episodes individual
page to get the metadata we want.

Tested on Win 10/Kodi Beta 1 and RPi3/LibreELEC 7.0.2

The only issue I've come up against I'm pretty sure is to do with how
Kodi handles and stores cookies. I've had to clear the cookes.dat file a
couple of times to get rid of HTTP 403 errors. If it ends up being a
recurring issue I can implement manual processing of the m3u8 and
cookies. See this thread on the Kodi forum for a similar example -
[http://forum.kodi.tv/showthread.php?tid=232439&pid=2057557]

fixed #1928 