### PR TITLE
Remove cookies.dat on each playback

### DIFF
--- a/resources/lib/play.py
+++ b/resources/lib/play.py
@@ -37,6 +37,11 @@ import xbmcaddon
 def play(url):
 
     try:
+        # Remove cookies.dat for Kodi < 17.0 - causes issues with playback
+        cookies_dat = xbmc.translatePath('special://home/cache/cookies.dat')
+        if os.path.isfile(cookies_dat):
+            os.remove(cookies_dat)
+
         p = classes.Program()
         p.parse_xbmc_url(url)
         auth = utils.get_auth(p)


### PR DESCRIPTION
Fixes issue in Kodi versions prior to 17 where (incorrectly) persistant
session cookies would prevent playback of either live streams or reruns.