### PR TITLE
Fix authentication

### DIFF
--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -100,6 +100,7 @@ def get_stream_url(hn, url):
         session.mount('http://', HTTPAdapter(max_retries=5))
         session.mount('https://', HTTPAdapter(max_retries=5))
         session.verify = False
+        session.headers = {'User-Agent': config.USER_AGENT}
 
         auth = get_auth(hn)
 


### PR DESCRIPTION
Akamai wasn't liking that we were getting the cookies with a request using a 'requests' user-agent, then using a different user-agent when passing to Kodi.