### PR TITLE
Fix for duplicate entries in news categories

### DIFF
--- a/resources/lib/comm.py
+++ b/resources/lib/comm.py
@@ -139,7 +139,7 @@ def get_feed(keyword):
 def get_programme_from_feed(keyword):
     utils.log('Getting programme from feed (%s)' % keyword)
     feed = get_feed(keyword)
-    shows = parse.parse_programme_from_feed(feed)
+    shows = parse.parse_programme_from_feed(feed, keyword)
     return shows
 
 


### PR DESCRIPTION
Changes to iView API have these categories returning complete episode
listings rather than just the most recent. Filter out subsequent
episodes after finding the first, then process as normal.